### PR TITLE
Update test for AzureFileSyncServerEndpoint

### DIFF
--- a/DSCResources/AzureFileSyncServerEndpoint/AzureFileSyncServerEndpoint.psm1
+++ b/DSCResources/AzureFileSyncServerEndpoint/AzureFileSyncServerEndpoint.psm1
@@ -201,11 +201,11 @@ function Test-TargetResource {
 
     if (@($Registered).Count -eq 1) {
 
-        Write-Verbose "Found server with tegistered DisplayName $DisplayName : $($Registered.DisplayName)"
+        Write-Verbose "Found server with registered DisplayName $DisplayName : $($Registered.DisplayName)"
 
         $AzureStorageSyncGroup = Get-AzureRmStorageSyncGroup -ResourceGroupName $AzureFileSyncResourceGroup -StorageSyncServiceName $AzureFileSyncInstanceName
 
-        if (@($AzureStorageSyncGroup).Count -eq 1) {
+        if (@($AzureStorageSyncGroup).Count -ge 1) {
 
             $AzureStorageSyncServerEndpoint = Get-AzureRmStorageSyncServerEndpoint -ResourceGroupName $AzureFileSyncResourceGroup -StorageSyncServiceName $AzureFileSyncInstanceName -SyncGroupName $AzureFileSyncGroup | Select-Object *, @{n = 'ComputerName'; e = {$PSitem.DisplayName.Split('.')[0]}} | Where-Object ComputerName -eq $env:COMPUTERNAME
 


### PR DESCRIPTION
When having more than one syncgroup the dsc test returned false, and it was going to create a new AzureFileSyncGroup, but that offcourse failes when it is already present.

changeing the (@($AzureStorageSyncGroup).Count -ge 1) instead of -eq 1 will continue and results in the next cmdlet will find the appropriate AzureFileSyncGroup, and it will in the end return True

---

Also fixed a typo from tegistered to registered
